### PR TITLE
support controller update when the ami (configuration_id) changes

### DIFF
--- a/cohesivenet/resource_vns3_config.go
+++ b/cohesivenet/resource_vns3_config.go
@@ -186,7 +186,7 @@ func resourceVns3Config() *schema.Resource {
 			},
 			"configuration_id": &schema.Schema{
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 				Description: "Configuration id",
 			},
 		},

--- a/cohesivenet/resource_vns3_peering.go
+++ b/cohesivenet/resource_vns3_peering.go
@@ -15,8 +15,8 @@ func resourceVns3Peering() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourcePeeringCreate,
 		ReadContext:   resourcePeeringRead,
-		UpdateContext: resourceConfigUpdate,
-		DeleteContext: resourceConfigDelete,
+		UpdateContext: resourcePeeringUpdate,
+		DeleteContext: resourcePeeringDelete,
 		Schema: map[string]*schema.Schema{
 			"last_updated": &schema.Schema{
 				Type:     schema.TypeString,

--- a/cohesivenet/resource_vns3_route.go
+++ b/cohesivenet/resource_vns3_route.go
@@ -157,7 +157,6 @@ func resourceRoutesRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	flatRoutes := flattenRouteData(routesResponse)
 	d.Set("route", flatRoutes)
-	d.SetId(strconv.FormatInt(time.Now().Unix(), 10))
 	return diags
 }
 
@@ -189,7 +188,6 @@ func resourceRoutesUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 			return diag.FromErr(err)
 		}
 
-		d.SetId(strconv.FormatInt(time.Now().Unix(), 10))
 		d.Set("last_updated", time.Now().Format(time.RFC850))
 
 	}


### PR DESCRIPTION
- when the aws ami is changed, a new instance of a controller will be synced from an existing controller 